### PR TITLE
fix: Update repository URLs in package.json to reflect correct project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/subhamay-bhattacharyya-gha/github-action-template.git"
+    "url": "git+https://github.com/subhamay-bhattacharyya-gha/tf-validate-action.git"
   },
   "author": "Subhamay Bhattacharyya",
   "license": "MIT",
   "keywords": [],
   "bugs": {
-    "url": "https://github.com/subhamay-bhattacharyya-gha/github-action-template/issues"
+    "url": "https://github.com/subhamay-bhattacharyya-gha/tf-validate-action/issues"
   },
-  "homepage": "https://github.com/subhamay-bhattacharyya-gha/github-action-template#readme"
+  "homepage": "https://github.com/subhamay-bhattacharyya-gha/tf-validate-action#readme"
 }


### PR DESCRIPTION
This pull request updates the repository metadata in the `package.json` file to reflect a change in the project's name and URLs.

* Updated the `repository.url` to point to the new repository `tf-validate-action`.
* Updated the `bugs.url` and `homepage` to use the new repository URL.