### PR TITLE
fix: Update Terraform action to use consistent working directory handling

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,13 +22,16 @@ runs:
       uses: hashicorp/setup-terraform@v3
 
     - name: Terraform Init
-      run: terraform init -input=false
       shell: bash
-      working-directory: ${{ github.workspace }}/${{ inputs.working-directory }}
+      run: |
+        cd "${{ inputs.working-directory }}"
+        terraform init -input=false
 
     - name: Terraform FMT Check
       id: fmt
+      shell: bash
       run: |
+        cd "${{ inputs.working-directory }}"
         set -e
         if terraform fmt -check -recursive; then
           echo "✅ Terraform FMT check passed"
@@ -42,12 +45,12 @@ runs:
             exit 1
           fi
         fi
-      shell: bash
-      working-directory: ${{ github.workspace }}/${{ inputs.working-directory }}
 
     - name: Terraform Validate
       id: validate
+      shell: bash
       run: |
+        cd "${{ inputs.working-directory }}"
         set -e
         if terraform validate -no-color; then
           echo "✅ Terraform validation passed"
@@ -63,5 +66,3 @@ runs:
             exit 1
           fi
         fi
-      shell: bash
-      working-directory: ${{ github.workspace }}/${{ inputs.working-directory }}


### PR DESCRIPTION
This pull request updates the `action.yaml` file to improve the handling of the working directory in Terraform commands. The changes ensure that the working directory is explicitly set within the `run` scripts, making the configuration more consistent and removing redundant `working-directory` attributes.

### Improvements to Terraform command execution:

* Updated the `Terraform Init` step to include a `cd` command to navigate to the specified working directory within the `run` script, replacing the `working-directory` attribute.
* Added a `cd` command to the `Terraform FMT Check` step to set the working directory explicitly in the `run` script, ensuring consistency with other steps.
* Modified the `Terraform Validate` step to include a `cd` command in the `run` script, aligning it with the updated approach of explicitly setting the working directory.
* Removed redundant `working-directory` attributes from all relevant steps, as the directory is now set within the `run` scripts.