### PR TITLE
fix: Correct string formatting in action.yaml for consistency

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Terraform Validation and Formatting Checks"
-description: A composite GitHub Action that performs Terraform format (fmt) and configuration validation.
+description: "A composite GitHub Action that performs Terraform format (fmt) and configuration validation."
 
 inputs:
   terraform-dir:
@@ -12,7 +12,7 @@ inputs:
     description: "Git release tag to check out. If omitted, the latest commit on the default branch is used."
     required: false
     type: string
-    default: ''
+    default: ""
 
   ci-pipeline:
     description: "Set to 'true' to include the commit SHA in the Terraform state key (suitable for CI/CD). Use 'false' for static state keys."


### PR DESCRIPTION
This pull request includes minor formatting updates to the `action.yaml` file. The changes standardize the use of double quotes in descriptions and default values.

Formatting updates:

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL2-R2): Updated the description field to use double quotes consistently.
* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL15-R15): Changed the default value for the `terraform-dir` input from single quotes to double quotes for consistency.