### PR TITLE
fix: add a blank line for better readability in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
 
+
 permissions:
   contents: write         # Push tags and changelog commits
   issues: write           # Create GitHub Issues on failure


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/release.yaml` file by adding a blank line after the branch specification to improve readability.