### PR TITLE
refactor: reduce redundant debug output in Terraform FMT check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -74,13 +74,6 @@ runs:
       shell: bash
       working-directory: "${{ github.workspace }}/${{ inputs.terraform-dir }}"
       run: |
-        echo "📁 Current working directory: $(pwd)"
-        echo "📂 Directory contents (recursive):"
-        find . -type f -name "*.tf" -o -name "*.tfvars" -o -name "*.hcl" | sort
-        echo ""
-        echo "📋 All files and directories:"
-        ls -laR
-        echo "-------------------------------------------"
         if terraform fmt -check -recursive; then
           echo "✅ Terraform FMT check passed"
           echo "### ✅ Terraform FMT check passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request simplifies the `action.yaml` workflow by removing verbose debugging output before running the Terraform format check.

Workflow simplification:

* Removed several commands that printed the current working directory, listed all files and directories, and displayed the contents of Terraform-related files, reducing unnecessary output in the workflow logs.