### PR TITLE
docs: rename terraform-dir input to tf-config-path for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This composite GitHub Action performs the following tasks for Terraform code qua
 
 | Name             | Description                                                                 | Required | Default   |
 |------------------|-----------------------------------------------------------------------------|----------|-----------|
-| `terraform-dir`  | Relative path to the directory containing Terraform configuration files     | No       | `tf`      |
+| `tf-config-path` | Relative path from the repository root to the Terraform configuration directory. This is where your main.tf, variables.tf, and other Terraform files are located. | No       | `tf`      |
 | `release-tag`    | Git release tag to check out. If omitted, the current branch is used        | No       | `''`      |
 | `soft-fail`      | Set to `'true'` to continue the workflow even if formatting or validation fails | No   | `true`    |
 
@@ -60,7 +60,7 @@ jobs:
         id: tf-validate
         uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
-          terraform-dir: tf
+          tf-config-path: tf
           soft-fail: "false"
 
       - name: Display Status
@@ -78,7 +78,7 @@ jobs:
       - name: Run Terraform Validate Action
         uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
-          terraform-dir: tf
+          tf-config-path: infrastructure
           release-tag: v1.0.0
           soft-fail: "true"
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: "Terraform Validation and Formatting Checks"
 description: "A composite GitHub Action that performs Terraform format (fmt) and configuration validation."
 
 inputs:
-  terraform-dir:
-    description: "Relative path to the directory containing Terraform configuration files (e.g., 'tf', 'infrastructure')."
+  tf-config-path:
+    description: "Relative path from the repository root to the Terraform configuration directory. This is where your main.tf, variables.tf, and other Terraform files are located."
     required: false
     type: string
     default: "tf"
@@ -34,12 +34,12 @@ runs:
         echo "### 📋 Action Inputs" >> $GITHUB_STEP_SUMMARY
         echo "| Input | Value |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-        echo "| terraform-dir | ${{ inputs.terraform-dir }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| tf-config-path | ${{ inputs.tf-config-path }} |" >> $GITHUB_STEP_SUMMARY
         echo "| release-tag | ${{ inputs.release-tag }} |" >> $GITHUB_STEP_SUMMARY
         echo "| soft-fail | ${{ inputs.soft-fail }} |" >> $GITHUB_STEP_SUMMARY
         echo ""
         echo "🔧 Terraform Validate Action - Input Parameters:"
-        echo "  terraform-dir: ${{ inputs.terraform-dir }}"
+        echo "  tf-config-path: ${{ inputs.tf-config-path }}"
         echo "  release-tag: ${{ inputs.release-tag }}"
         echo "  soft-fail: ${{ inputs.soft-fail }}"
 
@@ -66,13 +66,13 @@ runs:
     - name: Initialize Terraform
       id: terraform-init
       shell: bash
-      working-directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
+      working-directory: ${{ github.workspace }}/${{ inputs.tf-config-path }}
       run: terraform init -backend=false
 
     - name: Check Terraform Formatting (FMT)
       id: terraform-fmt-check
       shell: bash
-      working-directory: "${{ github.workspace }}/${{ inputs.terraform-dir }}"
+      working-directory: "${{ github.workspace }}/${{ inputs.tf-config-path }}"
       run: |
         if terraform fmt -check -recursive; then
           echo "✅ Terraform FMT check passed"
@@ -90,7 +90,7 @@ runs:
     - name: Validate Terraform Configuration
       id: terraform-validate
       shell: bash
-      working-directory: "${{ github.workspace }}/${{ inputs.terraform-dir }}"
+      working-directory: "${{ github.workspace }}/${{ inputs.tf-config-path }}"
       run: |
         if terraform validate -no-color; then
           echo "✅ Terraform validation passed"


### PR DESCRIPTION
- Rename input parameter from `terraform-dir` to `tf-config-path` in action.yaml
- Update input description to be more descriptive and specify the directory contains main.tf, variables.tf, and other Terraform files
- Update all references to the input parameter throughout the action workflow steps
- Update README.md examples to use the new `tf-config-path` parameter name
- Update README.md input table with improved description for better user guidance
- Improves clarity by explicitly stating the parameter refers to the Terraform configuration directory path from repository root